### PR TITLE
add glViewPort updates

### DIFF
--- a/sdk/src/main/java/io/kickflip/sdk/av/CameraEncoder.java
+++ b/sdk/src/main/java/io/kickflip/sdk/av/CameraEncoder.java
@@ -486,6 +486,7 @@ public class CameraEncoder implements SurfaceTexture.OnFrameAvailableListener, R
 
                 if (mIncomingSizeUpdated) {
                     mFullScreen.getProgram().setTexSize(mSessionConfig.getVideoWidth(), mSessionConfig.getVideoHeight());
+                    GLES20.glViewport(0, 0, mSessionConfig.getVideoWidth(), mSessionConfig.getVideoHeight());
                     mIncomingSizeUpdated = false;
                 }
 
@@ -625,6 +626,7 @@ public class CameraEncoder implements SurfaceTexture.OnFrameAvailableListener, R
                 mFullScreen = new FullFrameRect(
                         new Texture2dProgram(Texture2dProgram.ProgramType.TEXTURE_EXT));
                 mFullScreen.getProgram().setTexSize(mSessionConfig.getVideoWidth(), mSessionConfig.getVideoHeight());
+                GLES20.glViewport(0, 0, mSessionConfig.getVideoWidth(), mSessionConfig.getVideoHeight());
                 mIncomingSizeUpdated = true;
                 mSurfaceTexture.attachToGLContext(mTextureId);
                 //mEglSaver.makeNothingCurrent();
@@ -688,6 +690,7 @@ public class CameraEncoder implements SurfaceTexture.OnFrameAvailableListener, R
         mFullScreen = new FullFrameRect(
                 new Texture2dProgram(Texture2dProgram.ProgramType.TEXTURE_EXT));
         mFullScreen.getProgram().setTexSize(width, height);
+        GLES20.glViewport(0, 0, width, height);
         mIncomingSizeUpdated = true;
     }
 

--- a/sdk/src/main/java/io/kickflip/sdk/av/CameraSurfaceRenderer.java
+++ b/sdk/src/main/java/io/kickflip/sdk/av/CameraSurfaceRenderer.java
@@ -91,6 +91,8 @@ class CameraSurfaceRenderer implements GLSurfaceView.Renderer {
     @Override
     public void onSurfaceChanged(GL10 unused, int width, int height) {
         Log.d(TAG, "onSurfaceChanged " + width + "x" + height);
+
+        GLES20.glViewport(0, 0, width, height);
     }
 
     @Override


### PR DESCRIPTION
add glViewPort updates whenever the surface is changed and whenever sessionConfig is reloaded to eliminate wrong proportions on the final video if the session config resolution changes from a high one to a low one and vice versa. This is also described here https://developer.android.com/guide/topics/graphics/opengl.html
I think kickflip doesn't have a problem yet with this since resolutions aren't frequently changed between recording but if they were you would notice that without glViewPort opengl draws wrongly proportioned frames (based on the initial resolution loaded into each context and not based on the recently changed resolution [e.g. via a new session config] ).
This should be tested on your side as well. 
:)