### PR TITLE
 Updated build.gradle variable definition syntax

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'android-library'
 
-versionInt=8
-versionName="1.1.1"
+def versionInt=8
+def mVersionName="1.1.1"
 
 android {
     compileSdkVersion 19
@@ -11,7 +11,7 @@ android {
         minSdkVersion 18
         targetSdkVersion 19
         versionCode versionInt
-        versionName versionName
+        versionName mVersionName
 
     }
     buildTypes {


### PR DESCRIPTION
This build file gave me an error in Android studio because the variables VersionInt and VersionName were not preceded with "def" to signal variable definition.

In addition, once that error was corrected, VersionName caused an error because it is a reserved name in Gradle, so I changed it to mVersionName.